### PR TITLE
Feature/question1

### DIFF
--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -40,39 +40,49 @@
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="0PX-k5-h7v"/>
                                 </constraints>
-                                <state key="normal" title="Text Viewに追加"/>
+                                <state key="normal" title="追加"/>
                                 <connections>
                                     <action selector="addText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="gOP-gR-XKp"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hHX-9c-k0G">
-                                <rect key="frame" x="143.5" y="552" width="127" height="30"/>
-                                <state key="normal" title="Text Viewをクリア">
+                                <rect key="frame" x="184" y="552" width="46" height="30"/>
+                                <state key="normal" title="クリア">
                                     <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="clearText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="tT2-bg-mRt"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="文字を入力してください" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w28-Pb-EsZ">
+                                <rect key="frame" x="112" y="285" width="191" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="h1I-2B-V7f" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="5CN-E1-JLh"/>
+                            <constraint firstItem="w28-Pb-EsZ" firstAttribute="centerX" secondItem="mcD-4C-Lu1" secondAttribute="centerX" id="4NL-HL-ejQ"/>
+                            <constraint firstItem="h1I-2B-V7f" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="5CN-E1-JLh"/>
+                            <constraint firstItem="w28-Pb-EsZ" firstAttribute="leading" secondItem="ymG-c6-NIW" secondAttribute="leading" constant="112" id="7QW-5a-KxF"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="top" secondItem="mcD-4C-Lu1" secondAttribute="bottom" constant="40" id="7sh-Zw-yFY"/>
                             <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="40" id="9S7-3c-cYn"/>
+                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="w28-Pb-EsZ" secondAttribute="bottom" constant="8" id="Jg6-v0-yCG"/>
                             <constraint firstItem="hHX-9c-k0G" firstAttribute="top" secondItem="h1I-2B-V7f" secondAttribute="bottom" constant="40" id="Jt8-jr-6ue"/>
-                            <constraint firstItem="hHX-9c-k0G" firstAttribute="centerX" secondItem="tUl-ih-lXm" secondAttribute="centerX" id="NBc-xO-i6a"/>
-                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="a4S-bN-by9"/>
-                            <constraint firstItem="SAC-3D-GIS" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="l5m-Al-GqV"/>
+                            <constraint firstItem="hHX-9c-k0G" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="NBc-xO-i6a"/>
+                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="a4S-bN-by9"/>
+                            <constraint firstItem="SAC-3D-GIS" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="l5m-Al-GqV"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerY" secondItem="AJf-tg-maZ" secondAttribute="centerY" id="qxP-vA-nDO"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="tUl-ih-lXm"/>
+                        <viewLayoutGuide key="safeArea" id="ymG-c6-NIW"/>
                     </view>
                     <connections>
                         <outlet property="addTextButton" destination="mcD-4C-Lu1" id="mCX-sP-Nbt"/>
                         <outlet property="clearTextButton" destination="hHX-9c-k0G" id="baO-2w-SfE"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
+                        <outlet property="textWarning" destination="w28-Pb-EsZ" id="1ZD-as-wCA"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nhm-ii-iwx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -16,6 +16,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text View" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
+                                <rect key="frame" x="87" y="384" width="240" height="128"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="128" id="3cK-wX-M8f"/>
+                                    <constraint firstAttribute="width" constant="240" id="uho-Ff-ZhJ"/>
+                                </constraints>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SAC-3D-GIS">
                                 <rect key="frame" x="87" y="240" width="240" height="34"/>
                                 <constraints>
@@ -29,28 +40,28 @@
                                 <constraints>
                                     <constraint firstAttribute="width" constant="240" id="0PX-k5-h7v"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
+                                <state key="normal" title="Text Viewに追加"/>
                                 <connections>
                                     <action selector="addText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="gOP-gR-XKp"/>
                                 </connections>
                             </button>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text View" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
-                                <rect key="frame" x="87" y="384" width="240" height="128"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="128" id="3cK-wX-M8f"/>
-                                    <constraint firstAttribute="width" constant="240" id="uho-Ff-ZhJ"/>
-                                </constraints>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hHX-9c-k0G">
+                                <rect key="frame" x="143.5" y="552" width="127" height="30"/>
+                                <state key="normal" title="Text Viewをクリア">
+                                    <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="clearText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="tT2-bg-mRt"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="5CN-E1-JLh"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="top" secondItem="mcD-4C-Lu1" secondAttribute="bottom" constant="40" id="7sh-Zw-yFY"/>
                             <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="40" id="9S7-3c-cYn"/>
+                            <constraint firstItem="hHX-9c-k0G" firstAttribute="top" secondItem="h1I-2B-V7f" secondAttribute="bottom" constant="40" id="Jt8-jr-6ue"/>
+                            <constraint firstItem="hHX-9c-k0G" firstAttribute="centerX" secondItem="tUl-ih-lXm" secondAttribute="centerX" id="NBc-xO-i6a"/>
                             <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="a4S-bN-by9"/>
                             <constraint firstItem="SAC-3D-GIS" firstAttribute="centerX" secondItem="AJf-tg-maZ" secondAttribute="centerX" id="l5m-Al-GqV"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerY" secondItem="AJf-tg-maZ" secondAttribute="centerY" id="qxP-vA-nDO"/>
@@ -59,6 +70,7 @@
                     </view>
                     <connections>
                         <outlet property="addTextButton" destination="mcD-4C-Lu1" id="mCX-sP-Nbt"/>
+                        <outlet property="clearTextButton" destination="hHX-9c-k0G" id="baO-2w-SfE"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
                     </connections>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -54,8 +54,8 @@
                                     <action selector="clearText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="tT2-bg-mRt"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="文字を入力してください" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w28-Pb-EsZ">
-                                <rect key="frame" x="112" y="285" width="191" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="文字を入力してください" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0EE-0l-18T">
+                                <rect key="frame" x="112" y="282" width="191" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -63,15 +63,15 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="w28-Pb-EsZ" firstAttribute="centerX" secondItem="mcD-4C-Lu1" secondAttribute="centerX" id="4NL-HL-ejQ"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="5CN-E1-JLh"/>
-                            <constraint firstItem="w28-Pb-EsZ" firstAttribute="leading" secondItem="ymG-c6-NIW" secondAttribute="leading" constant="112" id="7QW-5a-KxF"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="top" secondItem="mcD-4C-Lu1" secondAttribute="bottom" constant="40" id="7sh-Zw-yFY"/>
                             <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="40" id="9S7-3c-cYn"/>
-                            <constraint firstItem="mcD-4C-Lu1" firstAttribute="top" secondItem="w28-Pb-EsZ" secondAttribute="bottom" constant="8" id="Jg6-v0-yCG"/>
                             <constraint firstItem="hHX-9c-k0G" firstAttribute="top" secondItem="h1I-2B-V7f" secondAttribute="bottom" constant="40" id="Jt8-jr-6ue"/>
                             <constraint firstItem="hHX-9c-k0G" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="NBc-xO-i6a"/>
+                            <constraint firstItem="0EE-0l-18T" firstAttribute="leading" secondItem="ymG-c6-NIW" secondAttribute="leading" constant="112" id="Wfy-WK-fdR"/>
                             <constraint firstItem="mcD-4C-Lu1" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="a4S-bN-by9"/>
+                            <constraint firstItem="0EE-0l-18T" firstAttribute="top" secondItem="SAC-3D-GIS" secondAttribute="bottom" constant="8" id="bbM-s9-bsT"/>
+                            <constraint firstItem="0EE-0l-18T" firstAttribute="centerX" secondItem="mcD-4C-Lu1" secondAttribute="centerX" id="jgu-uI-bQ4"/>
                             <constraint firstItem="SAC-3D-GIS" firstAttribute="centerX" secondItem="ymG-c6-NIW" secondAttribute="centerX" id="l5m-Al-GqV"/>
                             <constraint firstItem="h1I-2B-V7f" firstAttribute="centerY" secondItem="AJf-tg-maZ" secondAttribute="centerY" id="qxP-vA-nDO"/>
                         </constraints>
@@ -82,7 +82,7 @@
                         <outlet property="clearTextButton" destination="hHX-9c-k0G" id="baO-2w-SfE"/>
                         <outlet property="textField" destination="SAC-3D-GIS" id="kBt-tg-yHt"/>
                         <outlet property="textView" destination="h1I-2B-V7f" id="dkf-fw-Acv"/>
-                        <outlet property="textWarning" destination="w28-Pb-EsZ" id="1ZD-as-wCA"/>
+                        <outlet property="warningLabel" destination="0EE-0l-18T" id="jM6-5z-zSE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Nhm-ii-iwx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/intern_2week_study/Question/Question1/Question1.storyboard
+++ b/intern_2week_study/Question/Question1/Question1.storyboard
@@ -16,17 +16,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text View" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
-                                <rect key="frame" x="87" y="384" width="240" height="128"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="128" id="3cK-wX-M8f"/>
-                                    <constraint firstAttribute="width" constant="240" id="uho-Ff-ZhJ"/>
-                                </constraints>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SAC-3D-GIS">
                                 <rect key="frame" x="87" y="240" width="240" height="34"/>
                                 <constraints>
@@ -41,7 +30,21 @@
                                     <constraint firstAttribute="width" constant="240" id="0PX-k5-h7v"/>
                                 </constraints>
                                 <state key="normal" title="Button"/>
+                                <connections>
+                                    <action selector="addText:" destination="HOv-YH-dfQ" eventType="touchUpInside" id="gOP-gR-XKp"/>
+                                </connections>
                             </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Text View" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="h1I-2B-V7f">
+                                <rect key="frame" x="87" y="384" width="240" height="128"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="128" id="3cK-wX-M8f"/>
+                                    <constraint firstAttribute="width" constant="240" id="uho-Ff-ZhJ"/>
+                                </constraints>
+                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -8,5 +8,15 @@ final class Question1ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        textField.text = ""
+        textView.text = ""
+    }
+    
+    @IBAction func addText(_ sender: Any) {
+        guard let textFieldValue = textField.text else {
+            return
+        }
+        textView.text += textFieldValue + "\n"
+        textField.text = ""
     }
 }

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -6,26 +6,24 @@ final class Question1ViewController: UIViewController {
     @IBOutlet weak var addTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
     @IBOutlet weak var clearTextButton: UIButton!
-    @IBOutlet weak var textWarning: UILabel!
+    @IBOutlet weak var warningLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         textField.text = ""
         textView.text = ""
-        textWarning.isHidden = true
+        warningLabel.isHidden = true
     }
     
     @IBAction func addText(_ sender: Any) {
-        guard let textFieldValue = textField.text else {
+        guard let inputText = textField.text else { return }
+        guard !inputText.isEmpty else {
+            warningLabel.isHidden = false
             return
         }
-        if textFieldValue == "" {
-            textWarning.isHidden = false
-        } else {
-            textWarning.isHidden = true
-            textView.text += textFieldValue + "\n"
-            textField.text = ""
-        }
+        warningLabel.isHidden = true
+        textView.text += inputText + "\n"
+        textField.text = ""
     }
     
     @IBAction func clearText(_ sender: Any) {

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -6,19 +6,26 @@ final class Question1ViewController: UIViewController {
     @IBOutlet weak var addTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
     @IBOutlet weak var clearTextButton: UIButton!
+    @IBOutlet weak var textWarning: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         textField.text = ""
         textView.text = ""
+        textWarning.isHidden = true
     }
     
     @IBAction func addText(_ sender: Any) {
         guard let textFieldValue = textField.text else {
             return
         }
-        textView.text += textFieldValue + "\n"
-        textField.text = ""
+        if textFieldValue == "" {
+            textWarning.isHidden = false
+        } else {
+            textWarning.isHidden = true
+            textView.text += textFieldValue + "\n"
+            textField.text = ""
+        }
     }
     
     @IBAction func clearText(_ sender: Any) {

--- a/intern_2week_study/Question/Question1/Question1ViewController.swift
+++ b/intern_2week_study/Question/Question1/Question1ViewController.swift
@@ -5,6 +5,7 @@ final class Question1ViewController: UIViewController {
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var addTextButton: UIButton!
     @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var clearTextButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,5 +19,9 @@ final class Question1ViewController: UIViewController {
         }
         textView.text += textFieldValue + "\n"
         textField.text = ""
+    }
+    
+    @IBAction func clearText(_ sender: Any) {
+        textView.text = ""
     }
 }


### PR DESCRIPTION
課題
---
[課題1](https://github.com/Caraquri/intern_2week_study_ios/issues/1)

概要
---
* 1-1 : addButtonを押した際にtextFieldに入っている文字をtextViewに追加する処理の実装
    * 起動時にtextViewを空にする
    * textViewは改行してから追加する


- 1-2 : clearTextButtonを追加し、textViewの文字を消す処理の実装

- 1-3 : addButtonを押した際、textFieldに文字が入っていない場合はtextViewに追加できないようにする処理の実装
（その際、TextFieldの下にLabelを追加し「赤文字」で「文字を入力してください」と警告を表示）


特に確認して頂きたい項目
---
- さらに簡潔な実装があるかどうか
- Autolayoutができているかどうか


動作確認用 Screenshots
---
- Text View に apple、banana を追加
<img src="https://user-images.githubusercontent.com/46450087/89994873-adc00f00-dcc3-11ea-97eb-f3176dd77625.png" width="300" />

- 直後に何も入力せずに追加ボタンを押す
<img src="https://user-images.githubusercontent.com/46450087/89994928-c2040c00-dcc3-11ea-82a6-42a98a5d6872.png" width="300" />

- その後に orange を追加
<img src="https://user-images.githubusercontent.com/46450087/89995042-eeb82380-dcc3-11ea-85b0-b9eb2d87236e.png" width="300" />

- Text Viewの中身を削除
<img src="https://user-images.githubusercontent.com/46450087/89995094-02fc2080-dcc4-11ea-9895-b4b9c2e1b1ee.png" width="300" />


参考URL
---
- https://liginc.co.jp/486271
- https://note.com/gokawashima/n/n409ddb56ba0c
- https://qiita.com/k-yamada-github/items/af0c4bce7a2ed1b47c43